### PR TITLE
[FEATURE] Add typescript support

### DIFF
--- a/marlint-server/package.json
+++ b/marlint-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linter-marlint",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "Linter for marlint",
   "repository": {
     "type": "git",

--- a/marlint-server/package.json
+++ b/marlint-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linter-marlint",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Linter for marlint",
   "repository": {
     "type": "git",

--- a/marlint/extension.ts
+++ b/marlint/extension.ts
@@ -21,7 +21,12 @@ export function activate(context: ExtensionContext) {
   };
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: ["javascript", "javascriptreact"]
+    documentSelector: [
+      "javascript",
+      "javascriptreact",
+      "typescript",
+      "typescriptreact"
+    ]
   };
 
   const disposable = new LanguageClient(

--- a/marlint/package.json
+++ b/marlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linter-marlint",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "Linter for marlint",
   "repository": {
     "type": "git",

--- a/marlint/package.json
+++ b/marlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linter-marlint",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Linter for marlint",
   "repository": {
     "type": "git",
@@ -12,7 +12,12 @@
   "engines": {
     "vscode": "^1.6.0"
   },
-  "activationEvents": ["onLanguage:javascript", "onLanguage:javascriptreact"],
+  "activationEvents": [
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact"
+  ],
   "main": "./out/extension",
   "scripts": {
     "vscode:prepublish": "npm run update-vscode && cd ../marlint-server && npm run build && cd ../marlint && npm run build",

--- a/marlint/yarn.lock
+++ b/marlint/yarn.lock
@@ -1553,9 +1553,10 @@ vscode-jsonrpc@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-2.4.0.tgz#51396030e13179555c939b791c29598058b8fbb4"
 
-vscode-languageclient@2:
+vscode-languageclient@^2.6.2:
   version "2.6.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-2.6.3.tgz#9a35f5955464588d966895313f5164ce9b184f3f"
+  resolved "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-2.6.3.tgz#9a35f5955464588d966895313f5164ce9b184f3f"
+  integrity sha1-mjX1lVRkWI2WaJUxP1FkzpsYTz8=
   dependencies:
     vscode-jsonrpc "^2.4.0"
     vscode-languageserver-types "^1.0.4"


### PR DESCRIPTION
## Summary

Add support for typescript by adding typescript & typescriptreact on activationEvents API

## Test plan
1. yarn
2. Use [vsce](https://github.com/microsoft/vscode-vsce) and run `vsce package` to create VSIX file
3. Install binary output and install extension via VSIX
4.  Run on `www/`

## Sample
![image](https://user-images.githubusercontent.com/23512622/73634542-0159fc00-4694-11ea-9bbb-1f8ed9d9ff06.png)
